### PR TITLE
Support for importing jsonl format (JSON Lines)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+.vscode

--- a/README.md
+++ b/README.md
@@ -146,6 +146,28 @@ and we need to import each feature object into CouchDB as separate documents, th
   cat myfile.json | couchimport --db mydb --type json --jsonpath "features.*"
 ``` 
 
+## Importing JSON Lines file
+
+If your source document is a [JSON Lines](http://jsonlines.org/) text file, `couchimport` can be used. Let's say your JSON Lines looks like this:
+
+```
+{"a":1}
+{"a":2}
+{"a":3}
+{"a":4}
+{"a":5}
+{"a":6}
+{"a":7}
+{"a":8}
+{"a":9}
+```
+
+and we need to import each line as a JSON object into CouchDB as separate documents, then this can be imported using the `type="jsonl"` argument:
+
+```
+  cat myfile.json | couchimport --db mydb --type jsonl
+``` 
+
 ## Environment variables
 
 * COUCH_URL - the url of the CouchDB instance (required, or to be supplied on the command line)
@@ -154,7 +176,7 @@ and we need to import each feature object into CouchDB as separate documents, th
 * COUCH_TRANSFORM - the path of a transformation function (not required)
 * COUCHIMPORT_META - a json object which will be passed to the transform function (not required)
 * COUCH_BUFFER_SIZE - the number of records written to CouchDB per bulk write (defaults to 500, not required)
-* COUCH_FILETYPE - the type of file being imported, either "text" or "json" (defaults to "text", not required)
+* COUCH_FILETYPE - the type of file being imported, either "text", "json" or "jsonl" (defaults to "text", not required)
 * COUCH_JSON_PATH - the path into the incoming JSON document (only required for COUCH_FILETYPE=json imports)
 * COUCH_PREVIEW - run in preview mode
 * COUCH_IGNORE_FIELDS - a comma-separated list of field names to ignore on import or export e.g. price,url,image
@@ -169,7 +191,7 @@ You can now optionally override the environment variables by passing in command-
 * --transform - the path of a transformation function (not required)
 * --meta - a json object which will be passed to the transform function (not required)
 * --buffer - the number of records written to CouchDB per bulk write (defaults to 500, not required)
-* --type - the type of file being imported, either "text" or "json" (defaults to "text", not required)
+* --type - the type of file being imported, either "text", "json" or "jsonl" (defaults to "text", not required)
 * --jsonpath - the path into the incoming JSON document (only required for type=json imports)
 * --preview - if 'true', runs in preview mode
 * --ignorefields - a comma-separated list of fields to ignore input or output

--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ and we need to import each line as a JSON object into CouchDB as separate docume
 
 ```
   cat myfile.json | couchimport --db mydb --type jsonl
+```
+
+## Importing a stream of JSONs
+
+If your source data is a lot of JSON objects meshed or appended together, `couchimport` can be used. Let's say your file:
+
+```
+{"a":1}{"a":2}  {"a":3}{"a":4}
+{"a":5}          {"a":6}
+{"a":7}{"a":8}
+
+
+
+{"a":9}
+```
+
+and we need to import each JSON objet to CouchDB as separate documents, then this can be imported using the `type="jsonl"` argument:
+
+```
+  cat myfile.json.blob | couchimport --db mydb --type jsonl
 ``` 
 
 ## Environment variables

--- a/app.js
+++ b/app.js
@@ -10,24 +10,30 @@ var fs = require('fs'),
 // rs - readable stream
 // opts - an options object, or null for defaults
 // callback - called when complete
-var importStream = function(rs, opts, callback) {
-  
+var importStream = function (rs, opts, callback) {
+
   // sort the paramters
   if (typeof callback == "undefined" && typeof opts == "function") {
     callback = opts;
     opts = null;
   }
-  
+
   // merge default options
   opts = defaults.merge(opts);
 
   // load dependencies
   var writer = require('./includes/writer.js')(opts.COUCH_URL, opts.COUCH_DATABASE, opts.COUCH_BUFFER_SIZE, opts.COUCH_PARALLELISM, opts.COUCH_IGNORE_FIELDS),
-      transformer = require('./includes/transformer.js')(opts.COUCH_TRANSFORM, opts.COUCH_META);
-  
-  // if this is a JSON stream
-  if (opts.COUCH_FILETYPE == "json") {
-    
+    transformer = require('./includes/transformer.js')(opts.COUCH_TRANSFORM, opts.COUCH_META);
+
+  if (opts.COUCH_FILETYPE == "jsonl") {
+    // pipe the file to a streaming JSON parser
+    var JSONStream = require('JSONStream');
+    rs.pipe(JSONStream.parse())
+      .pipe(transformer)  // process each object
+      .pipe(writer); // write the data
+  }
+  else if (opts.COUCH_FILETYPE == "json") {
+    // if this is a JSON stream
     if (!opts.COUCH_JSON_PATH) {
       var msg = "ERROR: you must specify a JSON path using --jsonpath or COUCH_JSON_PATH";
       debugimport(msg);
@@ -38,29 +44,29 @@ var importStream = function(rs, opts, callback) {
     rs.pipe(JSONStream.parse(opts.COUCH_JSON_PATH))
       .pipe(transformer)  // process each object
       .pipe(writer); // write the data
-      
+
   } else {
 
     // load the CSV parser
     var parse = require('csv-parse'),
-      objectifier = parse({delimiter: opts.COUCH_DELIMITER, columns: true, skip_empty_lines: true, relax: true});
-    
+      objectifier = parse({ delimiter: opts.COUCH_DELIMITER, columns: true, skip_empty_lines: true, relax: true });
+
     // pipe the input to the output, via transformation functions
     rs.pipe(objectifier)  // turn each line into an object
       .pipe(transformer)  // process each object
       .pipe(writer); // write the data
   }
-  
-  writer.on('writecomplete', function(data) {
+
+  writer.on('writecomplete', function (data) {
     debugimport('writecomplete', data);
     callback(null, data);
   });
-  
-  rs.on('error', function(e) {
+
+  rs.on('error', function (e) {
     debugimport('error', e);
     callback(e, null);
   });
-  
+
   return writer;
 };
 
@@ -68,12 +74,12 @@ var importStream = function(rs, opts, callback) {
 // filename - name of the file stream
 // opts - an options object, or null for defaults
 // callback - called when complete
-var importFile = function(filename, opts, callback) {
+var importFile = function (filename, opts, callback) {
   return importStream(fs.createReadStream(filename), opts, callback);
 };
 
-var strip = function(str) {
-  return str.replace(/\n/g,' ').replace(/\r/g,'');
+var strip = function (str) {
+  return str.replace(/\n/g, ' ').replace(/\r/g, '');
 }
 
 // export to a writable stream
@@ -82,41 +88,41 @@ var strip = function(str) {
 // callback - called when complete
 var exportStream = function (ws, opts, callback) {
   var escape = null;
-  
+
   // sort the paramters
   if (typeof callback == "undefined" && typeof opts == "function") {
     callback = opts;
     opts = null;
   }
-  
+
   // merge default options
   opts = defaults.merge(opts);
-  
+
   var total = 0,
     headings = [],
     lastsize = 0,
     reader = require('./includes/reader.js')(opts.COUCH_URL, opts.COUCH_DATABASE, opts.COUCH_BUFFER_SIZE);
 
   // export a row as a CSV
-  var exportAsCSV = function(row) {
-  
+  var exportAsCSV = function (row) {
+
     // ignore design docs
     if (row._id.match(/^_design/)) {
       return;
     }
-  
+
     // if we are extracting headings
     if (headings.length == 0) {
       headings = Object.keys(row);
-      opts.COUCH_IGNORE_FIELDS.forEach(function(f) {
+      opts.COUCH_IGNORE_FIELDS.forEach(function (f) {
         headings = _.without(headings, f);
       });
       ws.write(headings.join(opts.COUCH_DELIMITER) + "\n");
     }
-  
+
     // output columns
     var cols = [];
-    for(var i in headings) {
+    for (var i in headings) {
       var v = row[headings[i]];
       var t = typeof v;
       if (v == null) {
@@ -132,9 +138,9 @@ var exportStream = function (ws, opts, callback) {
     ws.write(cols.join(opts.COUCH_DELIMITER) + "\n");
   }
 
-  async.doUntil(function(callback){
-    reader(function(err, data) {
-      if(err) {
+  async.doUntil(function (callback) {
+    reader(function (err, data) {
+      if (err) {
         return callback(true);
       }
       lastsize = data.length;
@@ -146,25 +152,25 @@ var exportStream = function (ws, opts, callback) {
       callback(null);
     });
   },
-  function() {
-    return (lastsize == 0 || escape);
-  }, 
-  function(err){
-    debugexport("Output complete");
-    callback(escape, null);
-  });
-  
-  ws.on("error", function(err) {
+    function () {
+      return (lastsize == 0 || escape);
+    },
+    function (err) {
+      debugexport("Output complete");
+      callback(escape, null);
+    });
+
+  ws.on("error", function (err) {
     escape = err;
   });
-  
+
 };
 
 // export to a named file 
 // filename - name of the file stream
 // opts - an options object, or null for defaults
 // callback - called when complete
-var exportFile = function(filename, opts, callback) {
+var exportFile = function (filename, opts, callback) {
   exportStream(fs.createWriteStream(filename), opts, callback);
 };
 
@@ -179,14 +185,14 @@ var previewCSVFile = preview.file;
 // opts - an options object, or null for defaults
 // callback - called when complete
 var previewURL = preview.url;
- 
+
 
 // load the first 10k of a URL and parse the first 3 lines
 // URL - name of the file to load
 // opts - an options object, or null for defaults
 // callback - called when complete
 var previewStream = preview.stream;
- 
+
 module.exports = {
   importStream: importStream,
   importFile: importFile,

--- a/includes/config.js
+++ b/includes/config.js
@@ -34,7 +34,7 @@ if (typeof process.env.COUCHIMPORT_META != "undefined") {
 
 // if there is type specified
 if (typeof process.env.COUCH_FILETYPE == "string" && types.indexOf(process.env.COUCH_FILETYPE) != -1) {
-  theconfig.COUCH_FILETYPE = "json";
+  theconfig.COUCH_FILETYPE = process.env.COUCH_FILETYPE;
 }
 
 // if there is a buffer size specified

--- a/includes/config.js
+++ b/includes/config.js
@@ -5,95 +5,95 @@ var defaults = require('./defaults.js'),
   argv = require('minimist')(process.argv.slice(2));
 
 // configure the CouchDB params
-var types = ["text","json"];
+var types = ["text", "json", "jsonl"];
 
 // if we have a custom CouchDB url
-if( typeof process.env.COUCH_URL != "undefined") {
+if (typeof process.env.COUCH_URL != "undefined") {
   theconfig.COUCH_URL = process.env.COUCH_URL;
 }
 
 // if we have a custom CouchDB url
-if( typeof process.env.COUCH_DATABASE != "undefined") {
+if (typeof process.env.COUCH_DATABASE != "undefined") {
   theconfig.COUCH_DATABASE = process.env.COUCH_DATABASE;
 }
 
 // if we have a customised transformation function
-if( typeof process.env.COUCH_TRANSFORM != "undefined") {
-  theconfig.COUCH_TRANSFORM = require(path.resolve(process.cwd(),process.env.COUCH_TRANSFORM));
+if (typeof process.env.COUCH_TRANSFORM != "undefined") {
+  theconfig.COUCH_TRANSFORM = require(path.resolve(process.cwd(), process.env.COUCH_TRANSFORM));
 }
 
 // if we have overridden the delimeter field
-if( typeof process.env.COUCH_DELIMITER != "undefined") {
+if (typeof process.env.COUCH_DELIMITER != "undefined") {
   theconfig.COUCH_DELIMITER = process.env.COUCH_DELIMITER;
 }
 
 // if there is metadata specified
-if( typeof process.env.COUCHIMPORT_META != "undefined") {
+if (typeof process.env.COUCHIMPORT_META != "undefined") {
   theconfig.COUCHIMPORT_META = JSON.parse(process.env.COUCHIMPORT_META);
 }
 
 // if there is type specified
-if( typeof process.env.COUCH_FILETYPE == "string" && types.indexOf(process.env.COUCH_FILETYPE)!=-1) {
+if (typeof process.env.COUCH_FILETYPE == "string" && types.indexOf(process.env.COUCH_FILETYPE) != -1) {
   theconfig.COUCH_FILETYPE = "json";
 }
 
 // if there is a buffer size specified
-if( typeof process.env.COUCH_BUFFER_SIZE != "undefined") {
+if (typeof process.env.COUCH_BUFFER_SIZE != "undefined") {
   theconfig.COUCH_BUFFER_SIZE = parseInt(process.env.COUCH_BUFFER_SIZE);
 }
 
 // if there is a buffer size specified
-if( typeof process.env.COUCH_JSON_PATH != "undefined") {
+if (typeof process.env.COUCH_JSON_PATH != "undefined") {
   theconfig.COUCH_JSON_PATH = process.env.COUCH_JSON_PATH;
 }
 
 // if there is a parallelism specified
-if( typeof process.env.COUCH_PARALLELISM != "undefined") {
+if (typeof process.env.COUCH_PARALLELISM != "undefined") {
   theconfig.COUCH_PARALLELISM = parseInt(process.env.COUCH_PARALLELISM);
 }
 
 // if this is preview mode
-if( typeof process.env.COUCH_PREVIEW != "undefined") {
+if (typeof process.env.COUCH_PREVIEW != "undefined") {
   theconfig.COUCH_PREVIEW = true;
 }
 
 // list of field names to ignore
-if( typeof process.env.COUCH_IGNORE_FIELDS != "undefined") {
+if (typeof process.env.COUCH_IGNORE_FIELDS != "undefined") {
   theconfig.COUCH_IGNORE_FIELDS = process.env.COUCH_IGNORE_FIELDS.split(',');
 }
 
 // override with command-line parameters
-if(argv.url) {
+if (argv.url) {
   theconfig.COUCH_URL = argv.url;
 }
-if(argv.db) {
+if (argv.db) {
   theconfig.COUCH_DATABASE = argv.db;
 }
-if(argv.transform) {
-  theconfig.COUCH_TRANSFORM = require(path.resolve(process.cwd(),argv.transform))
+if (argv.transform) {
+  theconfig.COUCH_TRANSFORM = require(path.resolve(process.cwd(), argv.transform))
 }
-if(argv.delimiter) {
+if (argv.delimiter) {
   theconfig.COUCH_DELIMITER = argv.delimiter;
 }
-if(argv.meta) {
+if (argv.meta) {
   theconfig.COUCHIMPORT_META = JSON.parse(argv.meta);
 }
-if(argv.type && types.indexOf(argv.type)!=-1) {
+if (argv.type && types.indexOf(argv.type) != -1) {
   theconfig.COUCH_FILETYPE = argv.type;
 }
-if(argv.buffer) {
+if (argv.buffer) {
   theconfig.COUCH_BUFFER_SIZE = parseInt(argv.buffer);
 }
-if(argv.jsonpath) {
+if (argv.jsonpath) {
   theconfig.COUCH_JSON_PATH = argv.jsonpath;
 }
-if(argv.parallelism) {
+if (argv.parallelism) {
   theconfig.COUCH_PARALLELISM = parseInt(argv.parallelism);
 }
-if(argv.preview) {
+if (argv.preview) {
   theconfig.COUCH_PREVIEW = true;
 }
-if(argv.ignorefields) {
+if (argv.ignorefields) {
   theconfig.COUCH_IGNORE_FIELDS = argv.ignorefields.split(',');
 }
 


### PR DESCRIPTION
### [JSON Lines](http://jsonlines.org/) is a newline-delimited JSON.
It is used a lot in logs.  

This feature helped me import a few TBs a bit faster.

The main advantage over the `json` mode is you don't have to make sure the input is a valid array.
If you have millions of JSON files it can take some time to create this array.
Sometimes it's easier to just pipe the JSON to `couchimport`.

### Example
You have a large zip file with thousands of nested JSON files in it. You just need to do:
`7z x -so test.zip | jq -c . | couchimport --db mydb --type jsonl`

Good luck!

EDIT:
After further checking, you could also just run
`7z x -so test.zip | couchimport --db mydb --type jsonl`
 I initially thought that `jq -c` is mandatory in order to output each json in a newline, but then I saw that the `JSONStream` can handle just a stream of JSONs.
e.g. `echo '{"a":1}{"b":2}' | couchimport --db mydb --type jsonl` will create 2 documents.
 
