### PR TITLE
Adds a --version switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 
 ## Configuration
 
-CouchImport's configuration parameters are stored in environment variables.
+CouchImport's configuration parameters can be stored in environment variables or supplied as command line arguments.
 
 ### The location of CouchDB - default "http://localhost:5984"
 
@@ -114,7 +114,7 @@ Written 500  ( 2000 )
 
 ```
 
-The configuration, whether default or overriden from environment variables is show, followed by a line of output for each block of 500 documents written, plus a cumulative total.
+The configuration, whether default or overriden by environment variables or command line arguments, is shown.  This is followed by a line of output for each block of 500 documents written, plus a cumulative total.
 
 ## Preview mode
 
@@ -203,8 +203,9 @@ and we need to import each JSON objet to CouchDB as separate documents, then thi
 
 ## Command-line parameters
 
-You can now optionally override the environment variables by passing in command-line parameters:
+You can also configure `couchimport` and `couchexport` using command-line parameters:
 
+* --version - simply prints the version and exits
 * --url - the url of the CouchDB instance (required, or to be supplied in the environment)
 * --db - the database to deal with (required, or to be supplied in the environment)
 * --delimiter - the delimiter to use (default '\t', not required)

--- a/bin/couchexport.bin.js
+++ b/bin/couchexport.bin.js
@@ -2,6 +2,14 @@
 process.env.DEBUG=(process.env.DEBUG)?process.env.DEBUG+",couchexport":"couchexport"
 var couchimport = require('../app.js');
 var config = require('../includes/config.js');
-couchimport.exportStream(process.stdout, config, function(err,data) {
-});
+
+if(config.COUCHIMPORT_VERSION) {
+  // if this is set, just print the version and exit
+  var package_json = require('../package.json');
+  console.log(package_json.version);
+  process.exit();
+} else {
+  couchimport.exportStream(process.stdout, config, function(err,data) {
+  });
+}
  

--- a/bin/couchimport.bin.js
+++ b/bin/couchimport.bin.js
@@ -4,7 +4,12 @@ var debug = require('debug')('couchimport'),
   couchimport = require('../app.js'),
   config = require('../includes/config.js');
 
-if(config.COUCH_PREVIEW) {
+if(config.COUCHIMPORT_VERSION) {
+  // if this is set, just print the version and exit
+  var package_json = require('../package.json');
+  console.log(package_json.version);
+  process.exit();
+} else if(config.COUCH_PREVIEW) {
   couchimport.previewStream(process.stdin, config, function(err, data, delimiter) {
     switch(delimiter) {
       case ',': console.log("Detected a COMMA column delimiter"); break;

--- a/includes/config.js
+++ b/includes/config.js
@@ -93,13 +93,18 @@ if (argv.parallelism) {
 if (argv.preview) {
   theconfig.COUCH_PREVIEW = true;
 }
+if (argv.version) {
+  theconfig.COUCHIMPORT_VERSION = true;
+}
 if (argv.ignorefields) {
   theconfig.COUCH_IGNORE_FIELDS = argv.ignorefields.split(',');
 }
 
-debug("******************");
-debug("configuration");
-debug(JSON.stringify(theconfig, null, ' ').replace(/\/\/.+@/g, "//****:****@"));
-debug("******************");
+if(!theconfig.COUCHIMPORT_VERSION) {
+    debug("******************");
+    debug("configuration");
+    debug(JSON.stringify(theconfig, null, ' ').replace(/\/\/.+@/g, "//****:****@"));
+    debug("******************");
+}
 
 module.exports = theconfig;


### PR DESCRIPTION
This prints the current version of the package as set in `package.json` for both `couchimport` and `couchexport`.  README updated but I couldn't figure out how to test this change, recommendations welcome.