### PR TITLE
Corrected spelling of delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You can also configure `couchimport` and `couchexport` using command-line parame
 e.g.
 
 ```
-    cat test.csv | couchimport --database  bob --delimeter ","
+    cat test.csv | couchimport --database  bob --delimiter ","
 ```
 
 ## couchexport


### PR DESCRIPTION
Corrected spelling of delimiter in command line parameters example