### PR TITLE
`--json-path` to `--jsonpath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If your source document is a GeoJSON text file, `couchimport` can be used. Let's
 and we need to import each feature object into CouchDB as separate documents, then this can be imported using the `type="json"` argument and specifying the JSON path using the `json-path` argument:
 
 ```
-  cat myfile.json | couchimport --database mydb --type json --json-path "features.*"
+  cat myfile.json | couchimport --database mydb --type json --jsonpath "features.*"
 ``` 
 
 ## Importing JSON Lines file


### PR DESCRIPTION
documentation refers to a parameter `--json-path` while version 0.6.2 requires that the parameter be `--jsonpath`