### PR TITLE
allow transform function to return array of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# CouchImport 
+# CouchImport
 
 [![Build Status](https://travis-ci.org/glynnbird/couchimport.svg?branch=master)](https://travis-ci.org/glynnbird/couchimport) [![npm version](https://badge.fury.io/js/couchimport.svg)](https://badge.fury.io/js/couchimport)
 
 ## Introduction
 
-When populating CouchDB databases, often the source of the data is initially a CSV or TSV file. CouchImport is designed to assist you with importing flat data into CouchDB efficiently. 
+When populating CouchDB databases, often the source of the data is initially a CSV or TSV file. CouchImport is designed to assist you with importing flat data into CouchDB efficiently.
 It can be used either as command-line utilities `couchimport` and `couchexport` or the underlying functions can be used programatically:
 
 * simply pipe the data file to 'couchimport' on the command line
@@ -55,21 +55,22 @@ Define the name of the CouchDB database to write to by setting the "COUCH_DATABA
 
 ### Transformation function - default nothing
 
-Define the path of a file containing a transformation function e.g. 
+Define the path of a file containing a transformation function e.g.
 
 ```
   export COUCH_TRANSFORM="/home/myuser/transform.js"
 ```
 
-The file should: 
-* be a javascript file 
-* export one function that takes a single doc and returns the transformed version synchronously
+The file should:
+* be a javascript file
+* export one function that takes a single doc and returns a single object or
+  an array of objects if you need to split a row into multiple docs.
 
 (see examples directory). N.B it's best to use full paths for the transform function.
 
 ### Delimiter - default "\t"
 
-The define the column delimiter in the input data e.g. 
+The define the column delimiter in the input data e.g.
 
 ```
   export COUCH_DELIMITER=","
@@ -144,7 +145,7 @@ and we need to import each feature object into CouchDB as separate documents, th
 
 ```
   cat myfile.json | couchimport --database mydb --type json --json-path "features.*"
-``` 
+```
 
 ## Importing JSON Lines file
 
@@ -186,7 +187,7 @@ and we need to import each JSON objet to CouchDB as separate documents, then thi
 
 ```
   cat myfile.json.blob | couchimport --database mydb --type jsonl
-``` 
+```
 
 ## Environment variables
 
@@ -290,7 +291,7 @@ To import data from a readable stream (rs):
     });
 ```
 
-To import data from a named file: 
+To import data from a named file:
 
 ```
     couchimport.importFile("input.txt", opts, function(err,data) {
@@ -334,9 +335,9 @@ To preview a CSV/TSV on a URL:
 
 ## Monitoring an import
 
-Both `importStream` and `importFile` return an EventEmitter which emits 
+Both `importStream` and `importFile` return an EventEmitter which emits
 
-* `written` event on a successful write 
+* `written` event on a successful write
 * `writeerror` event when a complete write operation fails
 * `writecomplete` event after the last write has finished
 * `writefail` event when an individual line in the CSV fails to be saved as a doc
@@ -367,5 +368,3 @@ speed up large data imports e.g.
 ```
   cat bigdata.csv | couchimport --database mydb --parallelism 10 --delimiter ","
 ```
-
-

--- a/examples/transform_split_docs.js
+++ b/examples/transform_split_docs.js
@@ -1,0 +1,23 @@
+// example transformation function
+// -- split a row into multiple docs
+var x = function(row) {
+  var doc1 = {
+    _id: row.id,
+    name: row.name,
+    type: 'person'
+  }
+  var doc2 = {
+    _id: row.company_id,
+    name: row.company_name,
+    type: 'company'
+  }
+  for(var i in doc) {
+    var v = doc[i];
+    v = v.replace(/^"/,"");
+    v = v.replace(/"$/,"");
+    doc[i] = v;
+  }
+  return [doc1, doc2];
+}
+
+module.exports = x;

--- a/examples/transform_split_docs.js
+++ b/examples/transform_split_docs.js
@@ -5,18 +5,12 @@ var x = function(row) {
     _id: row.id,
     name: row.name,
     type: 'person'
-  }
+  };
   var doc2 = {
     _id: row.company_id,
     name: row.company_name,
     type: 'company'
-  }
-  for(var i in doc) {
-    var v = doc[i];
-    v = v.replace(/^"/,"");
-    v = v.replace(/"$/,"");
-    doc[i] = v;
-  }
+  };
   return [doc1, doc2];
 }
 

--- a/includes/transformer.js
+++ b/includes/transformer.js
@@ -1,18 +1,27 @@
 var stream = require('stream');
 
 module.exports = function(func, meta) {
-  
+
   var transformer = new stream.Transform( { objectMode: true } );
   transformer._transform = function (obj, encoding, done) {
+    var self = this
+
     // transform using custom function
     if(typeof func == "function") {
       obj = func(obj, meta);
     }
 
     // pass object to next stream handler
-    this.push( obj);
+    if (Array.isArray(obj)) {
+      obj.forEach(function (obj) {
+        self.push( obj)
+      })
+    } else {
+      this.push( obj);
+    }
+
     done();
   };
-  
+
   return transformer;
 }


### PR DESCRIPTION
hey @glynnbird let me know if you want to add that functionality to `couchimport` (or if I missed something). We use the script to import a big CSV table but need to split up the rows in multiple docs, so we need our transform script to be able to return an array. That PR allows for that, but it has no tests or documentation yet, waiting for your feedback first